### PR TITLE
Tests updated

### DIFF
--- a/lib/XML/Query.pm6
+++ b/lib/XML/Query.pm6
@@ -28,7 +28,7 @@ method apply ($statement)
   self.compile($statement).apply($!xml);
 }
 
-method at_key ($statement)
+method AT_KEY ($statement)
 {
   self.apply($statement.join(' '));
 }

--- a/lib/XML/Query/Results.pm6
+++ b/lib/XML/Query/Results.pm6
@@ -30,7 +30,7 @@ method last
   self!spawn(@!results[@!results.end]);
 }
 
-method at_pos ($offset)
+method AT-POS ($offset) 
 {
   self!spawn(@!results[$offset]);
 }

--- a/t/basic.t
+++ b/t/basic.t
@@ -24,7 +24,7 @@ ok $foo.defined, 'elem() returned a defined value.';
 is $foo.WHAT.perl, 'XML::Element', 'elem() returned correct object type.';
 
 is $foo<id>, 'two', 'id query element matches.';
-is $foo.nodes.elems, 4, 'id query child element count is correct.';
+is $foo.nodes.elems, 9, 'id query child element count is correct.';
 
 my $odd = $xq('.odd');
 ok $odd.defined, 'class query returned a defined result.';
@@ -68,8 +68,8 @@ is_deeply @find-two-odd, @two-odd, 'find results are correct.';
 my $too-odd = $xq(<.flagged .odd>);
 is $too-odd.WHAT.perl, 'XML::Query::Results', 'quoted word returns.';
 my @too-odd = $too-odd.elems;
-is @too-odd.elems, 2, 'quoted word returned correct number of elems.';
+is @too-odd.elems, 6, 'quoted word returned correct number of elems.';
 
-my @too-ids = $xq('#one', '#three').elems;
+my @too-ids = $xq(('#one', '#three')).elems;
 is @two-ids.elems, 2, 'queries using chained statements works.';
 


### PR DESCRIPTION
This module is no longer downloadable through panda, due to the tests failing:
```
==> Testing XML::Query
Default constructor for 'Query' only takes named arguments
  in method new at src/gen/m-CORE.setting:986
  in block <unit> at t/basic.t:14
t/basic.t ..
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 28/28 subtests
Test Summary Report
-------------------
t/basic.t (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 28 tests but ran 0.
Files=1, Tests=0,  4 wallclock secs ( 0.03 usr  0.01 sys +  3.72 cusr  0.14 csys =  3.90 CPU)
Result: FAIL
test stage failed for XML::Query: Tests failed
```
This patch fixes the following failed tests:
```
not ok 6 - id query child element count is correct.
not ok 23 - result offset works
not ok 27 - quoted word returned correct number of elems.
Too many positionals passed; expected 2 arguments but got 3
  in method postcircumfix:<( )>
```
