### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/XML/Query.pm6
+++ b/lib/XML/Query.pm6
@@ -1,6 +1,6 @@
 use XML;
 
-class XML::Query;
+unit class XML::Query;
 
 use XML::Query::Statement;
 

--- a/lib/XML/Query/Results.pm6
+++ b/lib/XML/Query/Results.pm6
@@ -1,6 +1,6 @@
 use XML;
 
-class XML::Query::Results;
+unit class XML::Query::Results;
 
 has @.results;        ## The matching elements.
 has $.parent;         ## The Statement that generated these results.

--- a/lib/XML/Query/Statement.pm6
+++ b/lib/XML/Query/Statement.pm6
@@ -1,6 +1,6 @@
 use XML::Query::Results;
 
-class XML::Query::Statement;
+unit class XML::Query::Statement;
 
 has $.statement;   ## The statement we represent.
 has $.parent;      ## The top-level XML::Query object.


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.