### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -63,7 +63,7 @@ is $two.WHAT.perl, 'XML::Query::Results', 'result offset works.';
 my $find-two-odd = $two.find('.odd');
 is $find-two-odd.WHAT.perl, 'XML::Query::Results', 'find returned results.';
 my @find-two-odd = $find-two-odd.elems;
-is_deeply @find-two-odd, @two-odd, 'find results are correct.';
+is-deeply @find-two-odd, @two-odd, 'find results are correct.';
 
 my $too-odd = $xq(<.flagged .odd>);
 is $too-odd.WHAT.perl, 'XML::Query::Results', 'quoted word returns.';


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants.  The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.