### PR TITLE
"postcircumfix:<( )>" is "CALL-ME" now

### DIFF
--- a/lib/XML/Query.pm6
+++ b/lib/XML/Query.pm6
@@ -33,7 +33,7 @@ method AT_KEY ($statement)
   self.apply($statement.join(' '));
 }
 
-method postcircumfix:<( )> ($statement)
+method CALL-ME ($statement)
 {
   self.apply($statement.join(','));
 }


### PR DESCRIPTION
I got following error when testing.

```
% perl6 -Ilib t/basic.t
1..28
Cannot find method 'CALL-ME'
  in block <unit> at t/basic.t:16

# Looks like you planned 28 tests, but ran 0
```