### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -2,7 +2,7 @@
 
 use v6;
 
-BEGIN { @*INC.push: './lib'; }
+use lib 'lib';
 
 use Test;
 use XML;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.